### PR TITLE
Remove z_order

### DIFF
--- a/cleartables.yaml
+++ b/cleartables.yaml
@@ -140,10 +140,6 @@
     comment: Type of rail
   - <<: *brunnel
   - <<: *layer
-  - &z_order
-    name: z_order
-    type: smallint
-    comment: Order of the feature for rendering purposes
 - name: roads
   type: line
   tagtransform: transportation.lua
@@ -177,7 +173,6 @@
     type: access
   - <<: *brunnel
   - <<: *layer
-  - <<: *z_order
 - name: road_areas
   type: polygon
   tagtransform: transportation.lua
@@ -200,7 +195,6 @@
     type: access
   - <<: *brunnel
   - <<: *layer
-  - <<: *z_order
   - <<: *way_area
 - name: road_points
   type: point

--- a/test-transportation.lua
+++ b/test-transportation.lua
@@ -97,14 +97,6 @@ assert(transform_road({highway="residential", bridge="yes", tunnel="yes"}).brunn
 assert(transform_road({highway="residential"}).layer == "0", "test failed: layer 0")
 assert(transform_road({highway="residential", layer="4"}).layer == "4", "test failed: layer 4")
 
--- check that layer is the most significant. we can do that without hard-coding
--- z_order values by comparing two different layers, in effect reproducing the
--- ORDER BY used in rendering
-assert(tonumber(transform_road({highway="residential", layer="3"}).z_order) ==
-       tonumber(transform_road({highway="residential", layer="2"}).z_order), "test failed: residential layer z_order")
-assert(tonumber(transform_road({highway="residential", tunnel="yes", layer="3"}).z_order) <
-       tonumber(transform_road({highway="motorway", layer="2", bridge="yes"}).z_order), "test failed: residential/motorway layer z_order")
-
 assert(transform_road({highway="residential", oneway="yes"}).oneway == "true", "test failed: residential oneway=yes")
 assert(transform_road({highway="residential", oneway="no"}).oneway == "false", "test failed: residential oneway=no")
 assert(transform_road({highway="residential", oneway="-1"}).oneway == "reverse", "test failed: residential oneway=-1")

--- a/transportation.lua
+++ b/transportation.lua
@@ -10,38 +10,35 @@ Code for the transportation layers. These are some of the most complex. There's 
 
  - Separate tables are needed for roads and rail
  - A way might appear in both if it's both a road and rail
- - z_order is consistent across highways and rail, allowing a UNION ALL to be done
  - Non-moterized lines are processed to avoid highway=path insanity
 
 ]]--
 require "common"
 
 local highway = {
-    motorway        = {z=36, class="motorway", oneway="yes", motor_access="yes", bicycle="no", ramp="false"},
-    trunk           = {z=35, class="trunk", motor_access="yes", ramp="false"},
-    primary         = {z=34, class="primary", motor_access="yes", bicycle="yes", ramp="false"},
-    secondary       = {z=33, class="secondary", motor_access="yes", bicycle="yes", ramp="false"},
-    tertiary        = {z=32, class="tertiary", motor_access="yes", bicycle="yes", ramp="false"},
-    unclassified    = {z=31, class="minor", motor_access="yes", bicycle="yes", ramp="false"},
-    residential     = {z=31, class="minor", motor_access="yes", bicycle="yes", ramp="false"},
-    road            = {z=31, class="unknown", motor_access="yes"}, -- Should this be a class of nil?
-    living_street   = {z=30, class="minor", motor_access="yes"},
+    motorway        = {class="motorway", oneway="yes", motor_access="yes", bicycle="no", ramp="false"},
+    trunk           = {class="trunk", motor_access="yes", ramp="false"},
+    primary         = {class="primary", motor_access="yes", bicycle="yes", ramp="false"},
+    secondary       = {class="secondary", motor_access="yes", bicycle="yes", ramp="false"},
+    tertiary        = {class="tertiary", motor_access="yes", bicycle="yes", ramp="false"},
+    unclassified    = {class="minor", motor_access="yes", bicycle="yes", ramp="false"},
+    residential     = {class="minor", motor_access="yes", bicycle="yes", ramp="false"},
+    road            = {class="unknown", motor_access="yes"}, -- Should this be a class of nil?
+    living_street   = {class="minor", motor_access="yes"},
 
-    motorway_link   = {z=26, class="motorway", oneway="yes", motor_access="yes", ramp="true"},
-    trunk_link      = {z=25, class="trunk", oneway="yes", motor_access="yes", ramp="true"},
-    primary_link    = {z=24, class="primary", oneway="yes", motor_access="yes", ramp="true"},
-    secondary_link  = {z=23, class="secondary", oneway="yes", motor_access="yes", ramp="true"},
-    tertiary_link   = {z=22, class="tertiary", oneway="yes", motor_access="yes", ramp="true"},
+    motorway_link   = {class="motorway", oneway="yes", motor_access="yes", ramp="true"},
+    trunk_link      = {class="trunk", oneway="yes", motor_access="yes", ramp="true"},
+    primary_link    = {class="primary", oneway="yes", motor_access="yes", ramp="true"},
+    secondary_link  = {class="secondary", oneway="yes", motor_access="yes", ramp="true"},
+    tertiary_link   = {class="tertiary", oneway="yes", motor_access="yes", ramp="true"},
 
-    service         = {z=15, class="service", motor_access="yes", bicycle="yes"},
-    track           = {z=12, class="track"},
-    pedestrian      = {z=11, class="path", motor_access="no"},
-    path            = {z=10, class="path", motor_access="no"},
-    footway         = {z=10, class="path", motor_access="no"},
-    cycleway        = {z=10, class="path", motor_access="no", bicycle="yes"},
-    steps           = {z=10, class="path", motor_access="no"},
-
-    proposed        = {z=1}
+    service         = {class="service", motor_access="yes", bicycle="yes"},
+    track           = {class="track"},
+    pedestrian      = {class="path", motor_access="no"},
+    path            = {class="path", motor_access="no"},
+    footway         = {class="path", motor_access="no"},
+    cycleway        = {class="path", motor_access="no", bicycle="yes"},
+    steps           = {class="path", motor_access="no"}
 }
 
 local railway = {
@@ -143,7 +140,6 @@ function transform_road (tags)
         cols.maxspeed = speed(tags["maxspeed"])
         cols.brunnel = brunnel(tags)
         cols.layer = layer(tags["layer"])
-        cols.z_order = highway[tags["highway"]]["z"] or 0
     end
     return cols
 end
@@ -156,7 +152,6 @@ function transform_rail (tags)
         cols.class = railway[tags["railway"]]["class"]
         cols.brunnel = brunnel(tags)
         cols.layer = layer(tags["layer"])
-        cols.z_order = railway[tags["railway"]]["z"] or 0
     end
     return cols
 end


### PR DESCRIPTION
Fixes #35 

When using a type for transportation/road class which has a sensible ordering, z_order is unnecessary.
