### PR TITLE
Remove old-style multipolygon support

### DIFF
--- a/test-generic.lua
+++ b/test-generic.lua
@@ -71,10 +71,10 @@ local p1 = function (tags, cols, filter, polygon)
         {filter, cols, polygon, 0})
 end
 
-assert(p1({}, {INT_empty="true"}, 1, 0), "test failed: no tags")
-assert(p1({area="yes"}, {INT_rejected="true"}, 1, 0), "test failed: unaccepted area")
+assert(p1({}, {}, 1, 0), "test failed: no tags")
+assert(p1({area="yes"}, {}, 1, 0), "test failed: unaccepted area")
 assert(p1({area="yes", foo="bar"}, {area="yes", foo="bar"}, 0, 1), "test failed: accepted area")
-assert(p1({area="no", foo="bar"}, {INT_rejected="true"}, 1, 0), "test failed: accepted non-area")
+assert(p1({area="no", foo="bar"}, {}, 1, 0), "test failed: accepted non-area")
 
 print("TESTING: generic_multipolygon")
 
@@ -110,27 +110,6 @@ assert(check_generic_multipolygon(1, {}, {}, 0), "test failed: untagged relation
 assert(check_generic_multipolygon(1, {}, {foo="bar"}, 1), "test failed: other tagged relation")
 assert(check_generic_multipolygon(0, {type="multipolygon"}, {type="multipolygon"}, 1), "test failed: untagged multipolygon")
 assert(check_generic_multipolygon(0, {type="multipolygon", foo="bar"}, {type="multipolygon", foo="bar"}, 2), "test failed: tagged multipolygon")
-
--- yay multipolygons?
-print("TESTING: combine_member_tags")
-assert(deepcompare(combine_member_cols({}), nil), "test failed: no members")
-assert(deepcompare(combine_member_cols({{INT_rejected="true"}}), nil), "test failed: rejected member")
-assert(deepcompare(combine_member_cols({{INT_empty="true"}}), nil), "test failed: empty member")
-assert(deepcompare(combine_member_cols({{INT_rejected="true"}, {INT_rejected="true"}}), nil), "test failed: rejected members")
-assert(deepcompare(combine_member_cols({{INT_empty="true"}, {INT_empty="true"}}), nil), "test failed: empty members")
-assert(deepcompare(combine_member_cols({{foo="bar"}}), {foo="bar"}), "test failed: one member, tags")
-assert(deepcompare(combine_member_cols({{foo="bar"}, {INT_empty="true"}}), {foo="bar"}), "test failed: two members, cols on first")
-assert(deepcompare(combine_member_cols({{foo="bar"}, {INT_rejected="true"}}), nil), "test failed: two members, cols on first, second rejected")
-assert(deepcompare(combine_member_cols({{INT_empty="true"}, {foo="bar"}}), {foo="bar"}), "test failed: two members, cols on second")
-assert(deepcompare(combine_member_cols({{INT_rejected="true"}, {foo="bar"}}), nil), "test failed: two members, first rejected, cols on second")
-assert(deepcompare(combine_member_cols({{foo="bar"}, {foo="bar"}}), {foo="bar"}), "test failed: two members, tags on both")
-assert(deepcompare(combine_member_cols({{}}), {}), "test failed: member with no cols")
-assert(deepcompare(combine_member_cols({{}, {}}), {}), "test failed: two members with no cols")
-assert(deepcompare(combine_member_cols({{}, {INT_empty="true"}}), {}), "test failed: member with no cols, empty member")
-assert(deepcompare(combine_member_cols({{}, {INT_rejected="true"}}), nil), "test failed: member with no cols, rejected member")
-assert(deepcompare(combine_member_cols({{INT_empty="true"}, {}}), {}), "test failed: rejected member, member with no cols")
-assert(deepcompare(combine_member_cols({{INT_rejected="true"}, {}}), nil), "test failed: rejected member, member with no cols")
-assert(combine_member_cols({{foo="bar"}, {baz="qax"}}) == nil, "test failed: two members, different cols")
 
 print("TESTING: generic_multipolygon_members")
 -- generic_multipolygon_members is (tags, member_tags, membercount, accept, transform) -> (filter, cols, member_superseded, boundary, polygon, roads)
@@ -184,38 +163,14 @@ assert(deepcompare({foo_rel_members({}, {{bar="baz"}}, nil, 1)},
                    {1, {}, {0}, 0, 0, 0}), "test failed: untagged relation, member with cols")
 assert(deepcompare({foo_rel_members({}, {{}}, nil, 1)},
                    {1, {}, {0}, 0, 0, 0}), "test failed: untagged relation, member with no cols")
-assert(deepcompare({foo_rel_members({type="multipolygon"}, {{INT_rejected="true"}}, nil, 1)},
-                   {1, {}, {0}, 0, 1, 0}), "test failed: old-style MP, rejected member")
 assert(deepcompare({foo_rel_members({type="multipolygon"}, {{}}, nil, 1)},
-                   {0, {}, {1}, 0, 1, 0}), "test failed: old-style MP, member with no cols")
+                   {1, {}, {0}, 0, 1, 0}), "test failed: old-style MP, member with no cols")
 assert(deepcompare({foo_rel_members({type="multipolygon"}, {{bar="baz"}}, nil, 1)},
-                   {0, {bar="baz"}, {1}, 0, 1, 0}), "test failed: old-style MP, member with cols")
-assert(deepcompare({foo_rel_members({type="multipolygon"}, {{INT_rejected="true"}, {INT_rejected="true"}}, nil, 2)},
-                   {1, {}, {0, 0}, 0, 1, 0}), "test failed: old-style MP, rejected members")
+                   {1, {}, {0}, 0, 1, 0}), "test failed: old-style MP, member with cols")
 assert(deepcompare({foo_rel_members({type="multipolygon"}, {{}, {}}, nil, 2)},
-                   {0, {}, {1, 1}, 0, 1, 0}), "test failed: old-style MP, members with no cols")
+                   {1, {}, {0, 0}, 0, 1, 0}), "test failed: old-style MP, members with no cols")
 assert(deepcompare({foo_rel_members({type="multipolygon"}, {{bar="baz"}}, nil, 2)},
-                   {0, {bar="baz"}, {1, 1}, 0, 1, 0}), "test failed: old-style MP, members with cols")
-
-assert(deepcompare({foo_rel_members({type="multipolygon"}, {{}, {INT_empty="true"}}, nil, 2)},
-                   {0, {}, {1, 1}, 0, 1, 0}), "test failed: old-style MP, member with no cols, empty member")
-assert(deepcompare({foo_rel_members({type="multipolygon"}, {{INT_empty="true"}, {}}, nil, 2)},
-                   {0, {}, {1, 1}, 0, 1, 0}), "test failed: old-style MP, empty member, member with no cols")
-
-assert(deepcompare({foo_rel_members({type="multipolygon"}, {{}, {INT_rejected="true"}}, nil, 2)},
-                   {1, {}, {0, 0}, 0, 1, 0}), "test failed: old-style MP, member with no cols, rejected member")
-assert(deepcompare({foo_rel_members({type="multipolygon"}, {{INT_rejected="true"}, {}}, nil, 2)},
-                   {1, {}, {0, 0}, 0, 1, 0}), "test failed: old-style MP, rejected member, member with no cols")
-
-assert(deepcompare({foo_rel_members({type="multipolygon"}, {{foo="bar"}, {INT_empty="true"}}, nil, 2)},
-                   {0, {foo="bar"}, {1, 1}, 0, 1, 0}), "test failed: old-style MP, member with cols, empty member")
-assert(deepcompare({foo_rel_members({type="multipolygon"}, {{INT_empty="true"}, {foo="bar"}}, nil, 2)},
-                   {0, {foo="bar"}, {1, 1}, 0, 1, 0}), "test failed: old-style MP, empty member, member with cols")
-
-assert(deepcompare({foo_rel_members({type="multipolygon"}, {{foo="bar"}, {INT_rejected="true"}}, nil, 2)},
-                   {1, {}, {0, 0}, 0, 1, 0}), "test failed: old-style MP, member with cols, rejected member")
-assert(deepcompare({foo_rel_members({type="multipolygon"}, {{INT_rejected="true"}, {foo="bar"}}, nil, 2)},
-                   {1, {}, {0, 0}, 0, 1, 0}), "test failed: old-style MP, rejected member, member with cols")
+                   {1, {}, {0, 0}, 0, 1, 0}), "test failed: old-style MP, members with cols")
 
 -- Conflicting members
 assert(deepcompare({foo_rel_members({type="multipolygon"}, {{foo="bar"}, {}}, nil, 2)},


### PR DESCRIPTION
Old-style multipolygons have nearly disappeared, and removing them removes a lot of complicated and buggy code.