### PR TITLE
Handle national park boundary relations

### DIFF
--- a/cleartables.yaml
+++ b/cleartables.yaml
@@ -88,7 +88,7 @@
   tagtransform: protected.lua
   tagtransform-node-function: drop_all
   tagtransform-way-function: protected_ways
-  tagtransform-relation-function: generic_multipolygon
+  tagtransform-relation-function: generic_multipolygon_or_boundary
   tagtransform-relation-member-function: protected_rel_members
   tags:
   - <<: *name

--- a/protected.lua
+++ b/protected.lua
@@ -26,5 +26,5 @@ function protected_ways (tags, num_keys)
 end
 
 function protected_rel_members (tags, member_tags, member_roles, membercount)
-    return generic_multipolygon_members(tags, member_tags, membercount, accept_protected_area, transform_protected_area)
+    return generic_multipolygon_members(tags, member_tags, membercount, accept_protected_area, transform_protected_area, true)
 end

--- a/test-generic.lua
+++ b/test-generic.lua
@@ -111,8 +111,43 @@ assert(check_generic_multipolygon(1, {}, {foo="bar"}, 1), "test failed: other ta
 assert(check_generic_multipolygon(0, {type="multipolygon"}, {type="multipolygon"}, 1), "test failed: untagged multipolygon")
 assert(check_generic_multipolygon(0, {type="multipolygon", foo="bar"}, {type="multipolygon", foo="bar"}, 2), "test failed: tagged multipolygon")
 
+print("TESTING: generic_multipolygon_or_boundary")
+
+--- Check the output of generic_multipolygon_or_boundary
+-- @param filter Expected filter results
+-- @param out_tags Expected tags return
+-- @param in_tags Input tags
+-- @param num_keys Input num_keys
+
+local check_generic_multipolygon_or_boundary = function (filter, out_tags, in_tags, num_keys)
+    local actual_filter, actual_out_tags = generic_multipolygon_or_boundary(in_tags, num_keys)
+
+    if actual_filter ~= filter then
+        print("filter mismatch")
+        return false
+    end
+    if not deepcompare(actual_out_tags, out_tags) then
+        print("out_tags mismatch")
+        print("expected")
+        for k, v in pairs(out_tags) do
+            print(k, v)
+        end
+        print("actual")
+        for k, v in pairs(actual_out_tags) do
+            print(k, v)
+        end
+        return false
+    end
+    return true
+end
+
+assert(check_generic_multipolygon_or_boundary(1, {}, {}, 0), "test failed: untagged relation")
+assert(check_generic_multipolygon_or_boundary(1, {}, {foo="bar"}, 1), "test failed: other tagged relation")
+assert(check_generic_multipolygon_or_boundary(0, {type="boundary"}, {type="boundary"}, 1), "test failed: untagged boundary")
+assert(check_generic_multipolygon_or_boundary(0, {type="boundary", foo="bar"}, {type="boundary", foo="bar"}, 2), "test failed: tagged boundary")
+
 print("TESTING: generic_multipolygon_members")
--- generic_multipolygon_members is (tags, member_tags, membercount, accept, transform) -> (filter, cols, member_superseded, boundary, polygon, roads)
+-- generic_multipolygon_members is (tags, member_tags, membercount, accept, transform, acceptboundary) -> (filter, cols, member_superseded, boundary, polygon, roads)
 
 -- Construct a function to be called by osm2pgsql with mock accept and transform
 
@@ -123,8 +158,8 @@ print("TESTING: generic_multipolygon_members")
 -- @param membercount number of members
 -- @return filter, cols, member_superseded, boundary, polygon, roads
 -- member_roles is not used, so nil can be passed in
-local function foo_rel_members (tags, member_tags, member_roles, membercount)
-    return generic_multipolygon_members(tags, member_tags, membercount, acceptfoo, identity)
+local function foo_rel_members (tags, member_tags, member_roles, membercount, acceptboundary)
+    return generic_multipolygon_members(tags, member_tags, membercount, acceptfoo, identity, acceptboundary)
 end
 
 -- Tests of new-style MPs
@@ -137,6 +172,14 @@ assert(deepcompare({foo_rel_members({type="multipolygon", bar="baz"}, {{}}, nil,
 
 assert(deepcompare({foo_rel_members({type="multipolygon", foo="baz"}, {{}}, nil, 1)},
                    {0, {foo="baz"}, {0}, 0, 1, 0}), "test failed: MP with target tag")
+assert(deepcompare({foo_rel_members({type="boundary", foo="baz"}, {{}}, nil, 1)},
+                   {1, {}, {0}, 0, 0, 0}), "test failed: boundary with target tag")
+
+assert(deepcompare({foo_rel_members({type="multipolygon", foo="baz"}, {{}}, nil, 1, true)},
+                   {0, {foo="baz"}, {0}, 0, 1, 0}), "test failed: MP with target tag and acceptboundary")
+assert(deepcompare({foo_rel_members({type="boundary", foo="baz"}, {{}}, nil, 1, true)},
+                   {0, {foo="baz"}, {0}, 0, 1, 0}), "test failed: boundary with target tag and acceptboundary")
+
 assert(deepcompare({foo_rel_members({type="multipolygon", foo="baz"}, {{asdf="one"}}, nil, 1)},
                    {0, {foo="baz"}, {0}, 0, 1, 0}), "test failed: MP with target tag, way with different tags")
 assert(deepcompare({foo_rel_members({type="multipolygon", foo="baz"}, {{foo="baz"}}, nil, 1)},


### PR DESCRIPTION
National parks are tagged with type=boundary relations which need
to be handled like multipolygons. This extends generic_multipolygon_members
with an optional parameter for if boundaries should be accepted and
adds a new function for generic handling of MP or boundary relations.