### PR TITLE
Drop place polygon table

### DIFF
--- a/cleartables.yaml
+++ b/cleartables.yaml
@@ -63,23 +63,6 @@
     name: population
     type: integer
     comment: Population of the place
-- name: place_polygon
-  type: polygon
-  comment: Geographic places
-  tagtransform: place.lua
-  tagtransform-node-function: drop_all
-  tagtransform-way-function: place_ways
-  tagtransform-relation-function: generic_multipolygon
-  tagtransform-relation-member-function: place_rel_members
-  tags:
-  - <<: *name
-  - <<: *names
-  - name: class
-    type: text
-    comment: Classification of place
-  - <<: *place_rank
-  - <<: *population
-  - <<: *way_area
 # Protected areas
 - name: protected_area
   type: polygon

--- a/place.lua
+++ b/place.lua
@@ -55,11 +55,3 @@ end
 function place_nodes (tags, num_keys)
     return generic_node(tags, accept_place, transform_place)
 end
-
-function place_ways (tags, num_keys)
-    return generic_polygon_way(tags, accept_place, transform_place)
-end
-
-function place_rel_members (tags, member_tags, member_roles, membercount)
-    return generic_multipolygon_members(tags, member_tags, membercount, accept_place, transform_place)
-end


### PR DESCRIPTION
After much discussion on gravitystorm/openstreetmap-carto#2816 there's
no concensus about accepting places as polygons, so it's best to drop
them to be consistent with it and some other data consumers.